### PR TITLE
test(microservicio Node - MongoDB): Aplicación de tests al microservicio Node-MongoDB

### DIFF
--- a/microservice/apiNode/config.js
+++ b/microservice/apiNode/config.js
@@ -4,8 +4,8 @@ dotenv.config()
 export const config = {
 	dev: process.env.NODE_ENV !== 'production',
 	mongo: {
-		uri: process.env.MONGO_URI || 'localhost',
-		db: process.env.MONGO_DB || 'mongodb_data'
+		uri: process.env.MONGO_URI || 'mongodb+srv://admin:admin@cluster0.qcmsu.mongodb.net/',
+		db: process.env.MONGO_DB || 'myFirstDatabase'
 	},
 	mongodbService: {
 		host: process.env.MONGO_SRV_HOST || 'localhost',

--- a/microservice/apiNode/mongodb/index.js
+++ b/microservice/apiNode/mongodb/index.js
@@ -10,6 +10,10 @@ app.use(express.urlencoded({ extended: true }));
 // ROUTER
 app.use('/', router)
 
-app.listen(config.mongodbService.port, () => {
-	console.log('Servicio de MongoDB escuchando en el puerto ', config.mongodbService.port);
-})
+if(process.env.NODE_ENV != "test"){
+    app.listen(config.mongodbService.port, () => {
+		console.log('Servicio de MongoDB escuchando en el puerto ', config.mongodbService.port);
+	})
+}
+
+export {app}

--- a/microservice/apiNode/mongodb/network.js
+++ b/microservice/apiNode/mongodb/network.js
@@ -11,6 +11,7 @@ router.get('/:collection/:id', get)
 router.post('/:collection', insert)
 router.put('/:collection/:id', update)
 router.put('/:collection/:id/push', updatePush)
+router.delete('/:collection', removeAll)
 router.delete('/:collection/:id', remove)
 
 
@@ -40,6 +41,11 @@ async function update(req, res, next) {
 
 async function updatePush(req, res, next) {
 	const data = await Store.updatePush(req.params.collection, req.params.id, req.body)
+	response.success(req, res, data, 200);
+}
+
+async function removeAll(req, res, next) {
+	const data = await Store.deleteAll(req.params.collection)
 	response.success(req, res, data, 200);
 }
 

--- a/microservice/apiNode/mongodb/store/mongodb.js
+++ b/microservice/apiNode/mongodb/store/mongodb.js
@@ -1,5 +1,6 @@
 import pkgMongo from 'mongodb'
 import { config } from '../../config'
+import 'regenerator-runtime/runtime'
 const { MongoClient, ObjectId } = pkgMongo
 
 const MONGO_URI = config.mongo.uri
@@ -65,6 +66,12 @@ class MongoLib {
 		const db = await this.connect()
 		await db.collection(collection).deleteOne({ _id: ObjectId(id) })
 		return id
+	}
+
+	async deleteAll(collection) {
+		const db = await this.connect()
+		await db.collection(collection).deleteMany({})
+		return []
 	}
 }
 

--- a/microservice/apiNode/package.json
+++ b/microservice/apiNode/package.json
@@ -8,7 +8,8 @@
     "start": "node --es-module-specifier-resolution=node index.js",
     "dev": "nodemon --es-module-specifier-resolution=node index.js",
     "mongodb": "nodemon --es-module-specifier-resolution=node mongodb/index.js",
-    "test": "jest --detectOpenHandles --silent"
+    "test": "jest --detectOpenHandles --silent -- api.test.js",
+    "test-mongo": "jest --detectOpenHandles -- mongo.test.js"
   },
   "keywords": [],
   "author": "",

--- a/microservice/apiNode/tests/mongo.test.js
+++ b/microservice/apiNode/tests/mongo.test.js
@@ -1,0 +1,86 @@
+import supertest from 'supertest'
+import {app} from '../mongodb/index'
+import 'regenerator-runtime/runtime'
+
+const api = supertest(app)
+const newDocument = {
+    description: "documento de prueba",
+    arreglo: []
+}
+let idTest = "0"
+
+beforeAll(async ()=>{
+    await api.delete('/pruebas')
+})
+
+describe( 'Tests a la ruta /pruebas - Método GET', () => {
+    test('Se retorna la información en formato JSON', async () =>{
+        await api
+        .get('/pruebas')
+        .expect(200)
+        .expect('Content-Type',/application\/json/)
+    })
+
+    test('Se retorna inicialmente un arreglo vacío', async () =>{
+        const response = await api.get('/pruebas')
+        expect(response.body.body).toHaveLength(0)
+    })
+})
+
+describe( 'Tests a la ruta /pruebas - Método POST', () => {
+    test('Se retorna la información en formato JSON', async () =>{
+        const initialRsp = await api.get('/pruebas')
+        const initialLg = initialRsp.body.body.length
+        const responsePost = await api.post('/pruebas').send(newDocument)
+        idTest = responsePost.body.body._id
+        const responseGet = await api.get('/pruebas')
+        expect(responseGet.body.body).toHaveLength(initialLg + 1)
+    })
+})
+
+describe( 'Tests a la ruta /pruebas/<id> - Método GET', () => {
+    test('Se retorna la información en formato JSON', async () =>{
+        await api
+        .get(`/pruebas/${idTest}`)
+        .expect(200)
+        .expect('Content-Type',/application\/json/)
+    })
+
+    test('Se retorna la información añadida en el test de POST', async () =>{
+        const response = await api.get(`/pruebas/${idTest}`)
+        expect(response.body.body.description).toBe(newDocument.description)
+    })
+})
+
+describe( 'Tests a la ruta /pruebas/<id> - Método PUT', () => {
+    test('Se modifica el contenido de determinado atributo', async () =>{
+        await api.put(`/pruebas/${idTest}`).send({description: "documento de prueba - actualizado"})
+        const response = await api.get(`/pruebas/${idTest}`)
+        expect(response.body.body.description).toBe("documento de prueba - actualizado")
+    })
+})
+
+describe( 'Tests a la ruta /pruebas/<id>/push - Método PUT', () => {
+    test('Se añade un elemento a los atributos de tipo arreglo', async () =>{
+        await api.put(`/pruebas/${idTest}/push`).send({arreglo: "nuevo item"})
+        const response = await api.get(`/pruebas/${idTest}`)
+        expect(response.body.body.arreglo).toHaveLength(newDocument.arreglo.length + 1)
+    })
+})
+
+describe( 'Tests a la ruta /pruebas/<id>/push - Método DELETE', () => {
+    test('Se elimina un documento de la colección', async () =>{
+        const initialRsp = await api.get('/pruebas')
+        await api.delete(`/pruebas/${idTest}`)
+        const finalRsp = await api.get('/pruebas')
+        expect(finalRsp.body.body).toHaveLength(initialRsp.body.body.length - 1)
+    })
+})
+
+describe( 'Tests a la ruta /pruebas/<id>/push - Método DELETE', () => {
+    test('Se añade un elemento a los atributos de tipo arreglo', async () =>{
+        await api.delete('/pruebas')
+        const response = await api.get('/pruebas')
+        expect(response.body.body).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
Se aplicaron los tests correspondientes a cada uno de los endpoints implementados en el microservicio CRUD con MongoDB, para ello se hizo uso de las herramientas Jest y Supertest.
![image](https://user-images.githubusercontent.com/68212504/123037825-f735bc00-d3b4-11eb-9ef8-ab0a37f801c6.png)

Resolve : #191